### PR TITLE
Add rover with diagonal obstacle check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Test_Chat_GPT
+
+This repository contains a minimal Mars Rover simulation. The rover moves on a
+rectangular plateau and avoids obstacles. When an obstacle is directly in front
+of the rover, a subsequent left or right turn followed immediately by a forward
+movement is ignored so that the rover cannot slip past the obstacle diagonally.
+
+## Running the tests
+
+Execute the unit tests with:
+
+```bash
+python3 -m unittest discover
+```

--- a/plateau.py
+++ b/plateau.py
@@ -1,0 +1,13 @@
+class Plateau:
+    """Square grid plateau where the rover operates."""
+
+    def __init__(self, width, height, obstacles=None):
+        self.width = width
+        self.height = height
+        self.obstacles = set(obstacles or [])
+
+    def is_within_bounds(self, x, y):
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def is_free(self, x, y):
+        return self.is_within_bounds(x, y) and (x, y) not in self.obstacles

--- a/rover.py
+++ b/rover.py
@@ -1,0 +1,75 @@
+from plateau import Plateau
+
+# Orientation order for turning
+_ORIENTATIONS = ['N', 'E', 'S', 'W']
+
+# Movement deltas for orientations
+_MOVE = {
+    'N': (0, 1),
+    'E': (1, 0),
+    'S': (0, -1),
+    'W': (-1, 0),
+}
+
+class Rover:
+    """A rover that moves on a plateau while avoiding obstacles."""
+
+    def __init__(self, plateau: Plateau, x: int = 0, y: int = 0, direction: str = 'N'):
+        if direction not in _ORIENTATIONS:
+            raise ValueError(f"Invalid direction {direction}")
+        if not plateau.is_free(x, y):
+            raise ValueError("Starting position is not free")
+        self.plateau = plateau
+        self.x = x
+        self.y = y
+        self.direction = direction
+        # flag to prevent diagonal moves around obstacles
+        self._skip_next_forward = False
+
+    def _index(self) -> int:
+        return _ORIENTATIONS.index(self.direction)
+
+    def _blocked_ahead(self) -> bool:
+        dx, dy = _MOVE[self.direction]
+        nx, ny = self.x + dx, self.y + dy
+        return not self.plateau.is_free(nx, ny)
+
+    def turn_left(self):
+        if self._blocked_ahead():
+            self._skip_next_forward = True
+        idx = (self._index() - 1) % 4
+        self.direction = _ORIENTATIONS[idx]
+
+    def turn_right(self):
+        if self._blocked_ahead():
+            self._skip_next_forward = True
+        idx = (self._index() + 1) % 4
+        self.direction = _ORIENTATIONS[idx]
+
+    def forward(self):
+        if self._skip_next_forward:
+            # skip this move once to prevent diagonal bypass
+            self._skip_next_forward = False
+            return False
+        dx, dy = _MOVE[self.direction]
+        nx, ny = self.x + dx, self.y + dy
+        if self.plateau.is_free(nx, ny):
+            self.x, self.y = nx, ny
+            return True
+        return False
+
+    def execute_commands(self, commands):
+        """Execute a sequence of commands.
+
+        Commands should be an iterable containing 'L', 'R', or 'F'.
+        """
+        for cmd in commands:
+            if cmd == 'L':
+                self.turn_left()
+            elif cmd == 'R':
+                self.turn_right()
+            elif cmd == 'F':
+                self.forward()
+            else:
+                raise ValueError(f"Unknown command {cmd}")
+        return self.x, self.y, self.direction

--- a/tests/test_rover.py
+++ b/tests/test_rover.py
@@ -1,0 +1,30 @@
+import unittest
+from plateau import Plateau
+from rover import Rover
+
+class RoverTestCase(unittest.TestCase):
+    def test_forward_blocked_by_obstacle(self):
+        p = Plateau(3, 3, obstacles={(1, 2)})
+        r = Rover(p, 1, 1, 'N')
+        moved = r.forward()
+        self.assertFalse(moved)
+        self.assertEqual((r.x, r.y, r.direction), (1, 1, 'N'))
+
+    def test_no_diagonal_move_via_lf(self):
+        p = Plateau(3, 3, obstacles={(1, 2)})
+        r = Rover(p, 1, 1, 'N')
+        r.execute_commands('L')
+        r.execute_commands('F')
+        # forward should have been skipped due to obstacle ahead before turning
+        self.assertEqual((r.x, r.y, r.direction), (1, 1, 'W'))
+
+    def test_move_after_skipped_forward(self):
+        p = Plateau(4, 4, obstacles={(1, 2)})
+        r = Rover(p, 1, 1, 'N')
+        r.execute_commands('L')  # sets skip flag
+        r.execute_commands('F')  # skipped
+        r.execute_commands('F')  # this should move west
+        self.assertEqual((r.x, r.y, r.direction), (0, 1, 'W'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create plateau object
- create rover with obstacle handling
- block moves that combine a turn and immediate forward move when an obstacle is ahead
- document rover behavior and how to run tests
- add unit tests verifying obstacle rules

## Testing
- `python3 -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6852b545fd2083338aea0d73b24f42bb