### PR TITLE
Add REST API and UI for rover

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ movement is ignored so that the rover cannot slip past the obstacle diagonally.
 ## Running the tests
 
 Execute the unit tests with:
-
 ```bash
 python3 -m unittest discover
 ```
+
+## Running the REST API
+
+Install Flask if it is not already available and start the server:
+```bash
+python3 -m pip install Flask
+python3 server.py
+```
+Open `http://localhost:5000` in a browser to see the simple UI and control the rover.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,61 @@
+from flask import Flask, jsonify, request
+from plateau import Plateau
+from rover import Rover
+
+app = Flask(__name__)
+
+# Initial plateau and rover setup
+plateau = Plateau(5, 5, obstacles={(2, 2)})
+rover = Rover(plateau, 0, 0, 'N')
+
+@app.route('/status', methods=['GET'])
+def status():
+    return jsonify({
+        'x': rover.x,
+        'y': rover.y,
+        'direction': rover.direction,
+        'width': plateau.width,
+        'height': plateau.height,
+        'obstacles': sorted(list(plateau.obstacles))
+    })
+
+@app.route('/command', methods=['POST'])
+def command():
+    data = request.get_json(force=True)
+    commands = data.get('commands')
+    if not commands:
+        return jsonify({'error': 'commands field required'}), 400
+    try:
+        rover.execute_commands(commands)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
+    return status()
+
+@app.route('/')
+def index():
+    return '''<html><head>
+<script>
+async function sendCmd(){
+  const cmd = document.getElementById("cmd").value;
+  await fetch('/command',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({commands:cmd})});
+  load();
+}
+async function load(){
+  const res = await fetch('/status');
+  const data = await res.json();
+  document.getElementById('pos').textContent = `Position: (${data.x},${data.y})`;
+  document.getElementById('dir').textContent = `Direction: ${data.direction}`;
+  document.getElementById('ob').textContent = JSON.stringify(data.obstacles);
+}
+window.onload=load;
+</script></head>
+<body>
+<div id='pos'></div>
+<div id='dir'></div>
+<div>Obstacles: <span id='ob'></span></div>
+<input id='cmd'/>
+<button onclick='sendCmd()'>Send</button>
+</body></html>'''
+
+if __name__ == '__main__':
+    app.run()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,27 @@
+import unittest
+from server import app, rover
+
+class APITestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+        # reset rover state
+        rover.x = 0
+        rover.y = 0
+        rover.direction = 'N'
+
+    def test_status_endpoint(self):
+        resp = self.client.get('/status')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertEqual(data['x'], 0)
+        self.assertEqual(data['y'], 0)
+        self.assertEqual(data['direction'], 'N')
+
+    def test_command_sequence(self):
+        resp = self.client.post('/command', json={'commands': 'FFRFF'})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertEqual((data['x'], data['y'], data['direction']), (2, 2, 'E'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Flask-based REST API with simple HTML UI
- document how to run the REST server
- create API unit tests

## Testing
- `python3 -m unittest discover` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852b8664e108333b023da4fe0e2e9b8